### PR TITLE
fix: type for poolBorrowAPY on market

### DIFF
--- a/src/types/markets.ts
+++ b/src/types/markets.ts
@@ -319,7 +319,7 @@ export interface MarketData
   /** Borrow APY on Pool
    *
    * Number of decimals:
-   * `18` _(WEI)_
+   * `4` _(BASE_UNITS)_
    */
   readonly poolBorrowAPY: BigNumber;
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

Fix the documentation of TS indicating that poolBorrowAPY is 18 instead of 4.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
